### PR TITLE
Add in data repartitioning to batch inference.

### DIFF
--- a/pydata-seattle-2023/Model_finetuning_and_batch_inference.ipynb
+++ b/pydata-seattle-2023/Model_finetuning_and_batch_inference.ipynb
@@ -749,8 +749,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Shard data into 16 partitions for 16 workers.\n",
+    "val_shards = validation_dataset.repartition(16)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "prediction = predictor.predict(\n",
-    "    validation_dataset,\n",
+    "    val_shards,\n",
     "    num_gpus_per_worker=int(use_gpu),\n",
     "    batch_size=256,\n",
     "    max_new_tokens=128,\n",


### PR DESCRIPTION
Need to repartition the dataset to match the number of workers/actors that you want to utilize.